### PR TITLE
Fix chat meal logger fetch error

### DIFF
--- a/src/components/ChatMealLogger.tsx
+++ b/src/components/ChatMealLogger.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { logMealsText } from "../lib/api";
+import { logMealsText, API_BASE } from "../lib/api";
 
 export default function ChatMealLogger() {
   const [text, setText] = useState<string>(
@@ -14,7 +14,7 @@ lunch: 180 g shrimp, 129 g pasta, 1 glass mango juice`
 
   async function fetchDailyTotals() {
     try {
-      const response = await fetch("http://localhost:3001/api/logs");
+      const response = await fetch(`${API_BASE}/api/logs`);
       const csvText = await response.text();
       const lines = csvText.split('\n').filter(line => line.trim());
       const today = new Date().toISOString().split('T')[0];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,15 @@
+export const API_BASE = ((): string => {
+  // Prefer explicit base, then hostname-based fallback (handles remote/dev containers)
+  const explicit = (import.meta as any).env?.VITE_API_BASE as string | undefined;
+  if (explicit) return explicit.replace(/\/$/, "");
+  const host = typeof window !== "undefined" ? window.location.hostname : "localhost";
+  const port = (import.meta as any).env?.VITE_API_PORT ?? "3001";
+  const protocol = typeof window !== "undefined" ? window.location.protocol : "http:";
+  return `${protocol}//${host}:${port}`;
+})();
+
 export async function logMealsText(text: string) {
-  const res = await fetch("http://localhost:3001/api/log-text", {
+  const res = await fetch(`${API_BASE}/api/log-text`, {
     method: "POST",
     headers: { "Content-Type": "text/plain" },
     body: text
@@ -9,19 +19,19 @@ export async function logMealsText(text: string) {
 }
 
 export async function getDashboardAnalytics() {
-  const response = await fetch("http://localhost:3001/api/dashboard/analytics");
+  const response = await fetch(`${API_BASE}/api/dashboard/analytics`);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   return response.json();
 }
 
 export async function getGoals() {
-  const response = await fetch("http://localhost:3001/api/goals");
+  const response = await fetch(`${API_BASE}/api/goals`);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   return response.json();
 }
 
 export async function addGoal(goal_type: string, goal_value: number, goal_notes: string) {
-  const response = await fetch("http://localhost:3001/api/goals", {
+  const response = await fetch(`${API_BASE}/api/goals`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ goal_type, goal_value, goal_notes }),


### PR DESCRIPTION
Centralize API base URL to fix fetch errors caused by hardcoded `localhost` and mixed-content issues.

The original `fetch` calls used a hardcoded `http://localhost:3001`, which led to "Failed to fetch" errors. This could be due to the frontend running on a different host/port, or a secure (HTTPS) page attempting to fetch from an insecure (HTTP) endpoint, causing mixed-content blocking. This PR introduces a dynamic `API_BASE` that adapts to the current page's protocol and host, with an option for environment variable override, resolving these connectivity issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-63ea83b1-7b5c-4e7c-9fe0-33806d451ba5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63ea83b1-7b5c-4e7c-9fe0-33806d451ba5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

